### PR TITLE
LPS-61233 Portal Settings authentication.jsp no longer supports legacy hooks

### DIFF
--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/authentication.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/authentication.jsp
@@ -24,6 +24,8 @@ String tabsNames = (String)request.getAttribute(PortalSettingsWebKeys.AUTHENTICA
 tabsNames = (tabsNames.length() > 0) ? StringPool.COMMA + tabsNames : tabsNames;
 
 tabsNames = StringUtil.merge(PropsValues.COMPANY_SETTINGS_FORM_AUTHENTICATION) + tabsNames;
+
+tabsNames = (tabsNames.length() > 0) ? "general" + StringPool.COMMA + tabsNames : "general";
 %>
 
 <liferay-ui:error-marker key="errorSection" value="authentication" />
@@ -34,6 +36,10 @@ tabsNames = StringUtil.merge(PropsValues.COMPANY_SETTINGS_FORM_AUTHENTICATION) +
 	names="<%= tabsNames %>"
 	refresh="<%= false %>"
 >
+
+	<liferay-ui:section>
+		<liferay-util:include page='<%= "/authentication/general.jsp" %>' portletId="<%= portletDisplay.getRootPortletId() %>" />
+	</liferay-ui:section>
 
 	<%
 	for (String section : PropsValues.COMPANY_SETTINGS_FORM_AUTHENTICATION) {

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/authentication.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/authentication.jsp
@@ -46,7 +46,7 @@ tabsNames = (tabsNames.length() > 0) ? "general" + StringPool.COMMA + tabsNames 
 	%>
 
 		<liferay-ui:section>
-			<liferay-util:include page='<%= "/authentication/" + _getSectionJsp(section) + ".jsp" %>' portletId="<%= portletDisplay.getRootPortletId() %>" />
+			<liferay-util:include page='<%= "/html/portlet/portal_settings/authentication/" + _getSectionJsp(section) + ".jsp" %>' portletId="<%= PortletKeys.PORTAL %>" />
 		</liferay-ui:section>
 
 	<%

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/init.jsp
@@ -61,6 +61,7 @@ page import="com.liferay.portal.security.sso.OpenSSOUtil" %><%@
 page import="com.liferay.portal.service.*" %><%@
 page import="com.liferay.portal.settings.web.constants.PortalSettingsWebKeys" %><%@
 page import="com.liferay.portal.util.PortalUtil" %><%@
+page import="com.liferay.portal.util.PortletKeys" %><%@
 page import="com.liferay.portal.util.PrefsPropsUtil" %><%@
 page import="com.liferay.portal.util.PropsValues" %><%@
 page import="com.liferay.portal.util.TermsOfUseContentProvider" %><%@

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1953,7 +1953,7 @@
     # Input a list of sections that will be included as part of the company
     # authentication settings form.
     #
-    company.settings.form.authentication=general
+    company.settings.form.authentication=
 
 ##
 ## Users


### PR DESCRIPTION
Hi Philip,

this is a regression caused by moving Portal Settings portlet ouside portal context. If you don't mind I fixed it right away because we discussed it this morning with several people.

Thank you.

/cc @csierra @sergiogonzalez
